### PR TITLE
Trianglesphere/oom fix

### DIFF
--- a/android/src/main/java/com/reactnativegeth/RNGethModule.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethModule.java
@@ -88,6 +88,7 @@ public class RNGethModule extends ReactContextBaseJavaModule {
             if (config.hasKey("nodeDir")) nodeDir = config.getString("nodeDir");
             if (config.hasKey("keyStoreDir")) keyStoreDir = config.getString("keyStoreDir");
             if (config.hasKey("syncMode")) nc.setSyncMode(config.getInt("syncMode"));
+            if (config.hasKey("useLightweightKDF")) nc.setUseLightweightKDF(config.getBoolean("useLightweightKDF"));
             Node nd = Geth.newNode(getReactApplicationContext()
                     .getFilesDir() + "/" + nodeDir, nc);
             KeyStore ks = new KeyStore(getReactApplicationContext()

--- a/android/src/main/java/com/reactnativegeth/RNGethModule.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethModule.java
@@ -89,16 +89,6 @@ public class RNGethModule extends ReactContextBaseJavaModule {
             if (config.hasKey("keyStoreDir")) keyStoreDir = config.getString("keyStoreDir");
             if (config.hasKey("syncMode")) nc.setSyncMode(config.getInt("syncMode"));
             if (config.hasKey("useLightweightKDF")) nc.setUseLightweightKDF(config.getBoolean("useLightweightKDF"));
-            if (config.hasKey("useLightweightKDF")) {
-                Log.w("RNGethLog", "Has useLightweightKDF parameters");
-                if (config.getBoolean("useLightweightKDF")) {
-                    Log.w("RNGethLog", "useLightweightKDF is true");
-                } else {
-                    Log.w("RNGethLog", "useLightweightKDF is false");
-                }
-            } else {
-                Log.w("RNGethLog", "Does not have useLightweightKDF parameter");
-            }
             Node nd = Geth.newNode(getReactApplicationContext()
                     .getFilesDir() + "/" + nodeDir, nc);
             KeyStore ks = new KeyStore(getReactApplicationContext()

--- a/android/src/main/java/com/reactnativegeth/RNGethModule.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethModule.java
@@ -89,6 +89,16 @@ public class RNGethModule extends ReactContextBaseJavaModule {
             if (config.hasKey("keyStoreDir")) keyStoreDir = config.getString("keyStoreDir");
             if (config.hasKey("syncMode")) nc.setSyncMode(config.getInt("syncMode"));
             if (config.hasKey("useLightweightKDF")) nc.setUseLightweightKDF(config.getBoolean("useLightweightKDF"));
+            if (config.hasKey("useLightweightKDF")) {
+                Log.w("RNGethLog", "Has useLightweightKDF parameters");
+                if (config.getBoolean("useLightweightKDF")) {
+                    Log.w("RNGethLog", "useLightweightKDF is true");
+                } else {
+                    Log.w("RNGethLog", "useLightweightKDF is false");
+                }
+            } else {
+                Log.w("RNGethLog", "Does not have useLightweightKDF parameter");
+            }
             Node nd = Geth.newNode(getReactApplicationContext()
                     .getFilesDir() + "/" + nodeDir, nc);
             KeyStore ks = new KeyStore(getReactApplicationContext()

--- a/src/geth.js
+++ b/src/geth.js
@@ -18,6 +18,7 @@ import type {
  * @param {string} config.nodeDir Data directory for the databases and keystore
  * @param {string} config.keyStoreDir Directory for the keystore (default = inside the datadir)
  * @param {string} config.enodes Comma separated enode URLs for P2P discovery bootstrap
+ * @param {boolean} config.useLightweightKDF Use less secure but faster KDF
  */
 class Geth {
   config: ?NodeConfig


### PR DESCRIPTION
### Description

This passes `UseLightweightKDF` from the RNGeth Javascript object to the Geth node.
This must be merged after Geth,

This can be merged in the RNGeth, but the RNGeth version in the monorepo must be bumped after (or with) Geth's update.

### Tested

This PR along with the PRs in the other two repos was tested on both failing phones, and the phones no longer crashed on inputting the invite key (which causes a store of a private key which invokes scrypt with the standard parameters). Syncing not working, but that seemed to be an issue with test networks.

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/3254 and https://github.com/celo-org/celo-monorepo/issues/3693

### Backwards compatibility

Requires Geth AAR to be updated before being used (Java needs to see the exposed binding or the build will fail).