### PR TITLE
Latest geth support with IPCPath config

### DIFF
--- a/android/src/main/java/com/reactnativegeth/RNGethModule.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethModule.java
@@ -91,6 +91,7 @@ public class RNGethModule extends ReactContextBaseJavaModule {
             if (config.hasKey("keyStoreDir")) keyStoreDir = config.getString("keyStoreDir");
             if (config.hasKey("syncMode")) nc.setSyncMode(config.getInt("syncMode"));
             if (config.hasKey("useLightweightKDF")) nc.setUseLightweightKDF(config.getBoolean("useLightweightKDF"));
+            if (config.hasKey("ipcPath")) nc.setIPCPath(config.getString("ipcPath"));
             if (config.hasKey("logFile")) {
                 String logFileName = config.getString("logFile");
                 int logLevel = 3;  // Info

--- a/ios/NodeRunner.swift
+++ b/ios/NodeRunner.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Geth
+import CeloBlockchain
 
 class NodeRunner {
     private let ctx = GethNewContext()

--- a/ios/RNGeth.swift
+++ b/ios/RNGeth.swift
@@ -8,15 +8,27 @@
 import Foundation
 import Geth
 
+struct RuntimeError: LocalizedError {
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    public var errorDescription: String {
+        return message
+    }
+}
+
 @objc(RNGeth)
 class RNGeth: RCTEventEmitter, GethNewHeadHandlerProtocol {
-    func onError(_ failure: String!) {
-        NSLog("@", failure)
+    func onError(_ failure: String?) {
+        NSLog("@", failure!)
     }
     
     private var ETH_DIR: String = ".ethereum"
     private var KEY_STORE_DIR: String = "keystore"
-    private let ctx: GethContext
+    private let ctx: GethContext!
     private var geth_node: NodeRunner
     private var datadir = NSHomeDirectory() + "/Documents"
 
@@ -52,7 +64,7 @@ class RNGeth: RCTEventEmitter, GethNewHeadHandlerProtocol {
         return anyResult as? [String: String] ?? [:]
     }
     
-    func onNewHead(_ header: GethHeader) {
+    func onNewHead(_ header: GethHeader?) {
         guard bridge != nil else {
             // Don't call sendEvent when the bridge is not set
             // this happens when RN is reloaded and this module is unregistered
@@ -60,7 +72,10 @@ class RNGeth: RCTEventEmitter, GethNewHeadHandlerProtocol {
         }
 
         do {
-            let json = try header.encodeJSON()
+            var error: NSError?
+            guard let json = header?.encodeJSON(&error) else {
+                throw error ?? RuntimeError("Unable to encode geth header")
+            }
             let dict = try self.convertToDictionary(from: json)
             self.sendEvent(withName: "GethNewHead", body:dict)
         } catch let NSErr as NSError {
@@ -87,27 +102,28 @@ class RNGeth: RCTEventEmitter, GethNewHeadHandlerProtocol {
                 geth_node.writeStaticNodesFile(enodes: enodes)
             }
             if let networkID = config?["networkID"] as? Int64 {
-                nodeconfig.setEthereumNetworkID(networkID)
+                nodeconfig.ethereumNetworkID = networkID
             }
             if let maxPeers = config?["maxPeers"] as? Int {
-                nodeconfig.setMaxPeers(maxPeers)
+                nodeconfig.maxPeers = maxPeers
             }
             if let genesis = config?["genesis"] as? String {
-                nodeconfig.setEthereumGenesis(genesis)
+                nodeconfig.ethereumGenesis = genesis
             }
             if let syncMode = config?["syncMode"] as? Int {
-                nodeconfig.setSyncMode(syncMode)
+                nodeconfig.syncMode = syncMode
             }
             if let useLightweightKDF = config?["useLightweightKDF"] as? Bool {
-                nodeconfig.setUseLightweightKDF(useLightweightKDF)
+                nodeconfig.useLightweightKDF = useLightweightKDF
             }
 
-            let node: GethNode = GethNewNode(datadir + "/" + nodeDir, nodeconfig, &error)
-            let keyStore: GethKeyStore = GethNewKeyStore(keyStoreDir, GethLightScryptN, GethLightScryptP)
-            if error != nil {
-                reject(nil, nil, error)
-                return
+            guard let node = GethNewNode(datadir + "/" + nodeDir, nodeconfig, &error) else {
+                throw error ?? RuntimeError("Unable to create geth node")
             }
+            guard let keyStore = GethNewKeyStore(keyStoreDir, GethLightScryptN, GethLightScryptP) else {
+                throw RuntimeError("Unable to create geth key store")
+            }
+
             geth_node.setNodeConfig(nc: nodeconfig)
             geth_node.setKeyStore(ks: keyStore)
             geth_node.setNode(node: node)

--- a/react-native-geth.podspec
+++ b/react-native-geth.podspec
@@ -17,7 +17,4 @@ Pod::Spec.new do |s|
 
     s.dependency 'CeloBlockchain'
     s.dependency 'React'
-
-    s.libraries = 'bls_zexe'
-    s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '${PODS_ROOT}/../../../../node_modules/@celo/client/vendor/github.com/celo-org/bls-zexe/bls/target/universal/release' }
 end


### PR DESCRIPTION
This PR adds support for building with geth from https://github.com/celo-org/celo-blockchain/pull/528

It enables using a relative ipc path on iOS to workaround the 104 chars path limit for unix domain sockets.

It also simplifies the podspec. It only needs CeloBlockchain as a dependency.