### PR TITLE
Implement computeSharedSecret and decrypt

### DIFF
--- a/android/src/main/java/com/reactnativegeth/RNGethModule.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethModule.java
@@ -65,6 +65,7 @@ public class RNGethModule extends ReactContextBaseJavaModule {
     private static final String SIGN_HASH_PASSPHRASE_ERROR = "SIGN_HASH_PASSPHRASE_ERROR";
     private static final String ETH_DIR = ".ethereum";
     private static final String KEY_STORE_DIR = "keystore";
+    private static final String COMPUTE_SHARED_SECRET_ERROR = "COMPUTE_SHARED_SECRET_ERROR";
 
     private GethHolder gethHolder;
 
@@ -674,6 +675,26 @@ public class RNGethModule extends ReactContextBaseJavaModule {
         result.putDouble("discoveryPort", nodeInfo.getDiscoveryPort());
         result.putDouble("listenerPort", nodeInfo.getListenerPort());
         promise.resolve(result);
+    }
+
+    /**
+     * Retrieves the nodeInfo
+     *
+     * @param signer the address 
+     * @param publicKey Promise
+     * @param promise Promise
+     * @return return a map with node info
+     */
+    @ReactMethod
+    public void computeSharedSecret(String signer, String publicKeyBase64, Promise promise) {
+      try{
+        Account account = gethHolder.findAccount(signer);
+        byte[] publicKey = Base64.decode(publicKeyBase64, Base64.DEFAULT);
+        promise.resolve(gethHolder.getKeyStore().computeECDHSharedSecret(account, publicKey));
+      } catch (Exception e){
+        promise.reject(COMPUTE_SHARED_SECRET_ERROR, e);
+      }
+        
     }
 }
 

--- a/android/src/main/java/com/reactnativegeth/RNGethModule.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethModule.java
@@ -682,7 +682,7 @@ public class RNGethModule extends ReactContextBaseJavaModule {
     }
 
     /**
-     * Computes an ECDH shared secret between the user's privayeahte key and another user's public key
+     * Computes an ECDH shared secret between the user's private key and another user's public key
      *
      * @param address the address of the user
      * @param publicKey another user's public key

--- a/android/src/main/java/com/reactnativegeth/RNGethModule.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethModule.java
@@ -38,6 +38,9 @@ import org.ethereum.geth.Transaction;
 import org.ethereum.geth.NodeInfo;
 import org.ethereum.geth.Strings;
 
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
 public class RNGethModule extends ReactContextBaseJavaModule {
 
     private static final String TAG = "RNGeth";
@@ -66,6 +69,7 @@ public class RNGethModule extends ReactContextBaseJavaModule {
     private static final String ETH_DIR = ".ethereum";
     private static final String KEY_STORE_DIR = "keystore";
     private static final String COMPUTE_SHARED_SECRET_ERROR = "COMPUTE_SHARED_SECRET_ERROR";
+    private static final String DECRYPT_ERROR = "DECRYPT_ERROR";
 
     private GethHolder gethHolder;
 
@@ -678,7 +682,7 @@ public class RNGethModule extends ReactContextBaseJavaModule {
     }
 
     /**
-     * Computes an ECDH shared secret between the user's private key and another user's public key
+     * Computes an ECDH shared secret between the user's privayeahte key and another user's public key
      *
      * @param address the address of the user
      * @param publicKey another user's public key
@@ -690,11 +694,31 @@ public class RNGethModule extends ReactContextBaseJavaModule {
       try{
         Account account = gethHolder.findAccount(address);
         byte[] publicKey = Base64.decode(publicKeyBase64, Base64.DEFAULT);
-        promise.resolve(gethHolder.getKeyStore().computeECDHSharedSecret(account, publicKey));
+        byte[] secret = gethHolder.getKeyStore().computeECDHSharedSecret(account, publicKey);
+        promise.resolve(Base64.encodeToString(secret, Base64.DEFAULT));
       } catch (Exception e){
         promise.reject(COMPUTE_SHARED_SECRET_ERROR, e);
       }
         
     }
+
+    /**
+     * Decrypts an ECIES ciphertext
+     *
+     * @param address the address of the user
+     * @param cipher the cipher to be decrypted
+     * @param promise Promise
+     * @return return the decrypted text
+     */
+    // @ReactMethod
+    // public void decrypt(String address, Buffer cipher, Promise promise) {
+    //   try{
+    //     Account account = gethHolder.findAccount(address);
+    //     promise.resolve(gethHolder.getKeyStore().decrypt(account, cipher));
+    //   } catch (Exception e){
+    //     promise.reject(DECRYPT_ERROR, e);
+    //   }
+        
+    // }
 }
 

--- a/android/src/main/java/com/reactnativegeth/RNGethModule.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethModule.java
@@ -544,15 +544,15 @@ public class RNGethModule extends ReactContextBaseJavaModule {
      * Get the signature by either using the passphrase or if null, consider
      * the account unlocked
      * @param txRLPBase64 base64 encoded RLP transaction
-     * @param user the address signing the transaction
-     * @param passphrase the passphrase which unlocks the user
-     * @throws NoSuchElementException - when no account is found for the user
-     * @throws Exception - if the passphrase is wrong / user isn't unlocked
+     * @param signer the address signing the transaction
+     * @param passphrase the passphrase which unlocks the signer
+     * @throws NoSuchElementException - when no account is found for the signer
+     * @throws Exception - if the passphrase is wrong / signer isn't unlocked
      * @return return base64 encoded RLP of the signed transaction
      */
-    private String getTxSignature(String txRLPBase64, String user, String passphrase) throws Exception {
+    private String getTxSignature(String txRLPBase64, String signer, String passphrase) throws Exception {
         byte[] txRLP = Base64.decode(txRLPBase64, Base64.DEFAULT);
-        Account account = gethHolder.findAccount(user);
+        Account account = gethHolder.findAccount(signer);
         Transaction tx = new Transaction(txRLP);
         BigInt chainID = new BigInt(gethHolder.getNodeConfig().getEthereumNetworkID());
         Transaction signedTx;
@@ -568,14 +568,14 @@ public class RNGethModule extends ReactContextBaseJavaModule {
      * Signs a transaction with an unlocked account
      *
      * @param txRLPBase64 base64 encoded RLP transaction
-     * @param user the address signing the transaction
+     * @param signer the address signing the transaction
      * @param promise Promise
      * @return return base64 encoded RLP of the signed transaction
      */
     @ReactMethod
-    public void signTransaction(String txRLPBase64, String user, Promise promise) {
+    public void signTransaction(String txRLPBase64, String signer, Promise promise) {
         try {
-            promise.resolve(getTxSignature(txRLPBase64, user, null));
+            promise.resolve(getTxSignature(txRLPBase64, signer, null));
         } catch (Exception e) {
             promise.reject(SIGN_TRANSACTION_ERROR, e);
         }
@@ -585,15 +585,15 @@ public class RNGethModule extends ReactContextBaseJavaModule {
      * Signs a transaction with a passphrase
      *
      * @param txRLPBase64 base64 encoded RLP transaction
-     * @param user the address signing the transaction
-     * @param passphrase the passphrase which unlocks the user
+     * @param signer the address signing the transaction
+     * @param passphrase the passphrase which unlocks the signer
      * @param promise Promise
      * @return return base64 encoded RLP of the signed transaction
      */
     @ReactMethod
-    public void signTransactionPassphrase(String txRLPBase64, String user, String passphrase, Promise promise) {
+    public void signTransactionPassphrase(String txRLPBase64, String signer, String passphrase, Promise promise) {
         try {
-            promise.resolve(getTxSignature(txRLPBase64, user, passphrase));
+            promise.resolve(getTxSignature(txRLPBase64, signer, passphrase));
         } catch (Exception e) {
             promise.reject(SIGN_TRANSACTION_PASSPHRASE_ERROR, e);
         }
@@ -603,15 +603,15 @@ public class RNGethModule extends ReactContextBaseJavaModule {
      * Get the hash signature either by using the passphrase if it's provided
      * or by relying on the account being unlocked
      * @param hashBase64 base64 encoded hash
-     * @param user the address signing the hash
+     * @param signer the address signing the hash
      * @param passphrase (optional) the passphrase to unlock the account
-     * @throws NoSuchElementException - when no account is found for the user
-     * @throws Exception - if the passphrase is wrong / user isn't unlocked
+     * @throws NoSuchElementException - when no account is found for the signer
+     * @throws Exception - if the passphrase is wrong / signer isn't unlocked
      * @return The base64 encoded signature
      */
-    private String getHashSignature(String hashBase64, String user, String passphrase) throws Exception {
+    private String getHashSignature(String hashBase64, String signer, String passphrase) throws Exception {
         byte[] hashBytes = Base64.decode(hashBase64, Base64.DEFAULT);
-        Account account = gethHolder.findAccount(user);
+        Account account = gethHolder.findAccount(signer);
         byte[] signature;
         if (passphrase == null) {
             signature = gethHolder.getKeyStore().signHash(account.getAddress(), hashBytes);
@@ -625,14 +625,14 @@ public class RNGethModule extends ReactContextBaseJavaModule {
      * Signs a hash with an unlocked account
      *
      * @param hashBase64 base64 encoded hash
-     * @param user the address signing the hash
+     * @param signer the address signing the hash
      * @param promise Promise
      * @return return base64 encoded RLP of the signed transaction
      */
     @ReactMethod
-    public void signHash(String hashBase64, String user, Promise promise) {
+    public void signHash(String hashBase64, String signer, Promise promise) {
         try {
-            promise.resolve(getHashSignature(hashBase64, user, null));
+            promise.resolve(getHashSignature(hashBase64, signer, null));
         } catch (Exception e) {
             promise.reject(SIGN_HASH_ERROR, e);
         }
@@ -642,15 +642,15 @@ public class RNGethModule extends ReactContextBaseJavaModule {
      * Signs a hash with a passphrase
      *
      * @param hashBase64 base64 encoded RLP transaction
-     * @param user the address signing the transaction
-     * @param passphrase the passphrase to unlock the user
+     * @param signer the address signing the transaction
+     * @param passphrase the passphrase to unlock the signer
      * @param promise Promise
      * @return return base64 encoded RLP of the signed transaction
      */
     @ReactMethod
-    public void signHashPassphrase(String hashBase64, String user, String passphrase, Promise promise) {
+    public void signHashPassphrase(String hashBase64, String signer, String passphrase, Promise promise) {
         try {
-            promise.resolve(getHashSignature(hashBase64, user, passphrase));
+            promise.resolve(getHashSignature(hashBase64, signer, passphrase));
         } catch (Exception e) {
             promise.reject(SIGN_HASH_PASSPHRASE_ERROR, e);
         }

--- a/android/src/main/java/com/reactnativegeth/RNGethModule.java
+++ b/android/src/main/java/com/reactnativegeth/RNGethModule.java
@@ -710,15 +710,17 @@ public class RNGethModule extends ReactContextBaseJavaModule {
      * @param promise Promise
      * @return return the decrypted text
      */
-    // @ReactMethod
-    // public void decrypt(String address, Buffer cipher, Promise promise) {
-    //   try{
-    //     Account account = gethHolder.findAccount(address);
-    //     promise.resolve(gethHolder.getKeyStore().decrypt(account, cipher));
-    //   } catch (Exception e){
-    //     promise.reject(DECRYPT_ERROR, e);
-    //   }
+    @ReactMethod
+    public void decrypt(String address, String cipherBase64, Promise promise) {
+      try{
+        Account account = gethHolder.findAccount(address);
+        byte[] cipher = Base64.decode(cipherBase64, Base64.DEFAULT);
+        byte[] text = gethHolder.getKeyStore().decrypt(account, cipher);
+        promise.resolve(Base64.encodeToString(text, Base64.DEFAULT));
+      } catch (Exception e){
+        promise.reject(DECRYPT_ERROR, e);
+      }
         
-    // }
+    }
 }
 

--- a/ios/RNGeth.m
+++ b/ios/RNGeth.m
@@ -14,4 +14,6 @@ RCT_EXTERN_METHOD(signTransactionPassphrase:(NSString*)txRLPBase64 signer: (NSSt
 RCT_EXTERN_METHOD(signTransaction:(NSString*)txRLPBase64 signer: (NSString*)signer resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
 RCT_EXTERN_METHOD(signHashPassphrase:(NSString*)hashBase64 signer: (NSString*)signer passphrase: (NSString*)passphrase resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
 RCT_EXTERN_METHOD(signHash:(NSString*)hashBase64 signer: (NSString*)signer resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
+RCT_EXTERN_METHOD(computeSharedSecret:(NSString*)account publicKey: (NSString*)publicKey resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
+RCT_EXTERN_METHOD(decrypt:(NSString*)account ciphertext: (NSString*)ciphertext resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
 @end

--- a/ios/RNGeth.m
+++ b/ios/RNGeth.m
@@ -14,6 +14,6 @@ RCT_EXTERN_METHOD(signTransactionPassphrase:(NSString*)txRLPBase64 signer: (NSSt
 RCT_EXTERN_METHOD(signTransaction:(NSString*)txRLPBase64 signer: (NSString*)signer resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
 RCT_EXTERN_METHOD(signHashPassphrase:(NSString*)hashBase64 signer: (NSString*)signer passphrase: (NSString*)passphrase resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
 RCT_EXTERN_METHOD(signHash:(NSString*)hashBase64 signer: (NSString*)signer resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
-RCT_EXTERN_METHOD(computeSharedSecret:(NSString*)account publicKey: (NSString*)publicKey resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
-RCT_EXTERN_METHOD(decrypt:(NSString*)account ciphertext: (NSString*)ciphertext resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
+RCT_EXTERN_METHOD(computeSharedSecret:(NSString*)account publicKeyBase64: (NSString*)publicKeyBase64 resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
+RCT_EXTERN_METHOD(decrypt:(NSString*)account cipherBase64: (NSString*)cipherBase64 resolver: (RCTResponseSenderBlock)resolve rejecter:(RCTPromiseRejectBlock) reject)
 @end

--- a/ios/RNGeth.swift
+++ b/ios/RNGeth.swift
@@ -442,4 +442,52 @@ class RNGeth: RCTEventEmitter, GethNewHeadHandlerProtocol {
             reject(nil, nil, NSErr)
         }
     }
+
+    /**
+     * Computes an ECDH shared secret between the user's private key and another user's public key
+     *
+     * @param address the address of the user
+     * @param publicKey another user's public key
+     * @param promise Promise
+     * @return return a shared secret
+     */
+    @objc(computeSharedSecret:publicKeyBase64:resolver:rejecter:)
+    func computeSharedSecret(address: String, publicKeyBase64: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
+        do {
+            let keyStore = try runner.getKeyStore()
+            let account = try runner.findAccount(rawAddress: address)
+            guard let publicKey = Data(base64Encoded: publicKeyBase64) else {
+                throw RuntimeError("Invalid base64 encoded public key")
+            }
+            let secret = try keyStore.computeECDHSharedSecret(account, publicKey: publicKey)
+            resolve([secret.base64EncodedString()] as NSObject)
+        } catch let NSErr as NSError {
+            NSLog("@", NSErr)
+            reject(nil, nil, NSErr)
+        }
+    }
+
+    /**
+     * Decrypts an ECIES ciphertext
+     *
+     * @param address the address of the user
+     * @param cipher the cipher to be decrypted
+     * @param promise Promise
+     * @return return the decrypted text
+     */
+    @objc(decrypt:cipherBase64:resolver:rejecter:)
+    func decrypt(address: String, cipherBase64: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
+        do {
+            let keyStore = try runner.getKeyStore()
+            let account = try runner.findAccount(rawAddress: address)
+            guard let cipher = Data(base64Encoded: cipherBase64) else {
+                throw RuntimeError("Invalid base64 encoded ciphertext")
+            }
+            let text = try keyStore.decrypt(account, cipher: cipher)
+            resolve([text.base64EncodedString()] as NSObject)
+        } catch let NSErr as NSError {
+            NSLog("@", NSErr)
+            reject(nil, nil, NSErr)
+        }
+    }
 }

--- a/src/GethNativeModule.ts
+++ b/src/GethNativeModule.ts
@@ -101,9 +101,9 @@ export interface GethNativeModule {
    */
   listAccounts: () => Promise<string[]>;
   /**
-   * Add a new account
-   * @param account - the private key in base64
-   * @param publicKey - the passphrase used for the account
+   * Computes an ECDH shared secret between the user's private key and another user's public key
+   * @param account - the address of the account
+   * @param publicKey - another user's public key in base64
    * @returns the shared secret
    */
   computeSharedSecret: (account: string, publicKey: string) => Promise<Buffer>;    

--- a/src/GethNativeModule.ts
+++ b/src/GethNativeModule.ts
@@ -1,56 +1,55 @@
 /**
  * The configuration for a node
  */
-export type NodeConfig = {
-  bootnodeEnodes?: string[],
-  enodes?: string,
-  genesis?: string,
-  httpHost?: string,
-  httpModules?: string,
-  httpPort?: number,
-  httpVirtualHosts?: string,
-  ipcPath?: string
-  keyStoreDir?: string,
-  logFile?: string,
-  logFileLogLevel?: number,
-  maxPeers?: number,
-  networkID?: number,
-  noDiscovery?: boolean,
-  nodeDir?: string,
-  syncMode?: number
-  useLightweightKDF?: boolean,
-}
-
+export declare type NodeConfig = {
+  bootnodeEnodes?: string[];
+  enodes?: string;
+  genesis?: string;
+  httpHost?: string;
+  httpModules?: string;
+  httpPort?: number;
+  httpVirtualHosts?: string;
+  ipcPath?: string;
+  keyStoreDir?: string;
+  logFile?: string;
+  logFileLogLevel?: number;
+  maxPeers?: number;
+  networkID?: number;
+  noDiscovery?: boolean;
+  nodeDir?: string;
+  syncMode?: number;
+  useLightweightKDF?: boolean;
+};
 /**
- * GethNativeModule defines the interface for the native modules:
- * iOS:     RNGeth.m (exposed from RNGeth.swift)
- * Android: RNGethModule.java (marked with @ReactMethod)
- *
- * We currently have more methods implemented in Android then in iOS,
- * but this interface should hold the lowest common denominator.
- * We should extend this list as we implement/start using more.
- */
+* GethNativeModule defines the interface for the native modules:
+* iOS:     RNGeth.m (exposed from RNGeth.swift)
+* Android: RNGethModule.java (marked with @ReactMethod)
+*
+* We currently have more methods implemented in Android then in iOS,
+* but this interface should hold the lowest common denominator.
+* We should extend this list as we implement/start using more.
+*/
 export interface GethNativeModule {
   /**
    * Configure and prepare the node
    * @returns success status of operation
    */
-  setConfig: (config: NodeConfig) => Promise<boolean>,
+  setConfig: (config: NodeConfig) => Promise<boolean>;
   /**
    * Start creates a live P2P node and starts running it.
    * @returns success status of operation
    */
-  startNode: () => Promise<boolean>,
+  startNode: () => Promise<boolean>;
   /**
    * Terminates a running node along with all it's services.
    * @returns success status of operation
    */
-  stopNode: () => Promise<boolean>,
+  stopNode: () => Promise<boolean>;
   /**
    * Subscribes to notifications about the current blockchain head
    * @return true if subscribed
    */
-  subscribeNewHead: () => Promise<boolean>,
+  subscribeNewHead: () => Promise<boolean>;
   /**
    * Sign a RLP-encoded transaction with the passphrase
    * @param txRLPBase64 - The RLP encoded transaction
@@ -59,7 +58,7 @@ export interface GethNativeModule {
    * @param  passphrase - The passphrase for the signer's account
    * @returns the signed transaction in RLP as a base64 string
    */
-  signTransactionPassphrase: (txRLPBase64: string, signer: string, passphrase: string) => Promise<string>,
+  signTransactionPassphrase: (txRLPBase64: string, signer: string, passphrase: string) => Promise<string>;
   /**
    * Sign a RLP-encoded transaction with an unlocked account
    * @param txRLPBase64 - The RLP encoded transaction in base64
@@ -67,28 +66,27 @@ export interface GethNativeModule {
    * @param signer - Address of the signer (must be unlocked)
    * @returns the signed transaction in RLP as a base64 string
    */
-  signTransaction: (txRLPBase64: string, signer: string) => Promise<string>,
-
+  signTransaction: (txRLPBase64: string, signer: string) => Promise<string>;
   /**
    * Sign arbitrary hash with passphrase
    * @param hashHex - input to sign encoded as a hex string
    * @param signer - Address of the signer (can be locked)
    * @param passphrase - The passphrase for the signer's account
    */
-  signHashPassphrase: (hashBase64: string, signer: string, passphrase: string) => Promise<string>,
+  signHashPassphrase: (hashBase64: string, signer: string, passphrase: string) => Promise<string>;
   /**
    * Sign arbitrary hash
    * @param hashHex - input to sign encoded as a hex string
    * @param signer - Address of the signer (must be unlocked)
    */
-  signHash: (hashBase64: string, signer: string) => Promise<string>,
+  signHash: (hashBase64: string, signer: string) => Promise<string>;
   /**
    * Add a new account
    * @param privateKey - the private key in base64
    * @param passphrase - the passphrase used for the account
    * @returns the new account
    */
-  addAccount: (privateKeyBase64: string, passphrase: string) => Promise<string>,
+  addAccount: (privateKeyBase64: string, passphrase: string) => Promise<string>;
   /**
    * Unlock an account
    * @param address - the address to unlock
@@ -96,10 +94,17 @@ export interface GethNativeModule {
    * @param timeout - unlock duration in nanoseconds
    * @returns the unlocked status of the account
    */
-  unlockAccount: (account: string, passphrase: string, timeout: number) => Promise<boolean>,
+  unlockAccount: (account: string, passphrase: string, timeout: number) => Promise<boolean>;
   /**
    * Returns all key files present in the directory.
    * @returns all accounts
    */
-  listAccounts: () => Promise<string[]>,
+  listAccounts: () => Promise<string[]>;
+  /**
+   * Add a new account
+   * @param account - the private key in base64
+   * @param publicKey - the passphrase used for the account
+   * @returns the shared secret
+   */
+  computeSharedSecret: (account: string, publicKey: string) => Promise<Buffer>;    
 }

--- a/src/GethNativeModule.ts
+++ b/src/GethNativeModule.ts
@@ -106,12 +106,12 @@ export interface GethNativeModule {
    * @param publicKey - another user's public key in base64
    * @returns the shared secret
    */
-  computeSharedSecret: (account: string, publicKey: string) => Promise<Buffer>;
+  computeSharedSecret: (account: string, publicKey: string) => Promise<string>;
   /**
    * Decrypts an ECIES ciphertext
    * @param account - the address of the account
    * @param ciphertext - the cipher to be decrypted
    * @returns the decrypted text
    */
-  decrypt: (account: string, ciphertext: Buffer) => Promise<Buffer>;    
+  decrypt: (account: string, ciphertext: string) => Promise<string>;    
 }

--- a/src/GethNativeModule.ts
+++ b/src/GethNativeModule.ts
@@ -106,5 +106,12 @@ export interface GethNativeModule {
    * @param publicKey - another user's public key in base64
    * @returns the shared secret
    */
-  computeSharedSecret: (account: string, publicKey: string) => Promise<Buffer>;    
+  computeSharedSecret: (account: string, publicKey: string) => Promise<Buffer>;
+  /**
+   * Decrypts an ECIES ciphertext
+   * @param account - the address of the account
+   * @param ciphertext - the cipher to be decrypted
+   * @returns the decrypted text
+   */
+  decrypt: (account: string, ciphertext: Buffer) => Promise<Buffer>;    
 }


### PR DESCRIPTION
Implemented `computeSharedSecret` and `decrypt` functions to be consumed by the geth wallet in Android and iOS. 

Tested on Valora with [this branch](https://github.com/celo-org/celo-monorepo/compare/isabellewei/uploadCIP8Data), must be using `@celo/client` version 0.0.322