### PR TITLE
Add override keyword in overriding function declaration to prevent iOS build error

### DIFF
--- a/ios/RNGeth.swift
+++ b/ios/RNGeth.swift
@@ -51,7 +51,7 @@ class RNGeth: RCTEventEmitter, GethNewHeadHandlerProtocol {
     }
 
     // Called when React Native is reloaded
-    @objc func invalidate() {
+    @objc override func invalidate() {
         do {
             try runner.node?.stop()
         } catch {


### PR DESCRIPTION
The lack of explicit override keyword here caused the Valora build to fail when upgrading the react native version, so let's add it.